### PR TITLE
feature: add configurable amount of cached elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # lib-js-util-shard
 
-A library to determine shard indexes
+A library to determine shard indexes, uses a LRU cache for caching calculated values
 
 ```js
 const nodeCount = 3
 
+const u = new UtilShard({
+  // max: 5000,
+  // maxAge: maxAgeInMilliseconds
+})
 // get the numeric shard index for 'BTCUSD'
-const shardIndex = getStrRingIx('BTCUSD', nodeCount)
+const shardIndex = u.getStrRingIx('BTCUSD', nodeCount)
 ```
-
 
 ## API
 

--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
 'use strict'
 
 const CRC = require('crc-32')
+const LRU = require('lru')
 
 class UtilShard {
-  constructor () {
-    this.mem = {}
+  constructor (opts) {
+    this.mem = new LRU(opts)
   }
 
   getRingIx (v, n) {
@@ -17,12 +18,16 @@ class UtilShard {
 
   getStrVal (s) {
     const k = `s2i-${s}`
-    let v = this.mem[k]
+
+    let v = this.mem.get(k)
+
     if (v !== undefined) {
       return v
     }
 
-    v = this.mem[k] = Math.abs(CRC.str(s))
+    v = Math.abs(CRC.str(s))
+    this.mem.set(k, v)
+
     return v
   }
 }

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const CRC = require('crc-32')
 const LRU = require('lru')
 
 class UtilShard {
-  constructor (opts) {
+  constructor (opts = {}) {
     this.mem = new LRU(opts)
   }
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "crc-32": "^1.2.0"
   },
   "devDependencies": {
-    "mocha": "^8.2.1",
+    "mocha": "^8.4.0",
     "standard": "^16.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "author": "prdn",
   "license": "Apache-2.0",
   "dependencies": {
-    "crc-32": "^1.2.0"
+    "crc-32": "^1.2.0",
+    "lru": "^3.1.0"
   },
   "devDependencies": {
     "mocha": "^8.4.0",

--- a/test/cache.js
+++ b/test/cache.js
@@ -1,0 +1,28 @@
+/* eslint-env mocha */
+
+'use strict'
+
+const assert = require('assert')
+const UtilShard = require('../')
+
+describe('cache', () => {
+  it('caches elements', () => {
+    const u = new UtilShard()
+
+    u.getStrRingIx('a', 3)
+    assert.strictEqual(u.mem.get('s2i-a'), 390611389)
+
+    assert.strictEqual(u.getStrRingIx('a', 3), 1)
+  })
+
+  it('limits amount of cached elements', () => {
+    const u = new UtilShard({ max: 2 })
+
+    u.getStrRingIx('a', 3)
+    u.getStrRingIx('b', 3)
+    u.getStrRingIx('c', 3)
+    u.getStrRingIx('d', 3)
+
+    assert.strictEqual(u.mem.length, 2)
+  })
+})


### PR DESCRIPTION
the current code was storing all elements, when using on larger
datasets (e.g. user id) it would bloat up the memory.

this adds an option to set max count and max age for the cached
items. for backwards compat, the default is kept at unlimited.